### PR TITLE
risingwave 1.7.0-single-node

### DIFF
--- a/Formula/risingwave@1.6.rb
+++ b/Formula/risingwave@1.6.rb
@@ -1,0 +1,45 @@
+class Risingwave < Formula
+  desc "Distributed SQL database for stream processing"
+  homepage "https://github.com/risingwavelabs/risingwave"
+  url "https://github.com/risingwavelabs/risingwave/archive/refs/tags/v1.6.0.tar.gz"
+  sha256 "ddd9fd3a3f8ef333dcc2474fb2732787408acbfddcdd3b81216a74056ee9db29"
+  license "Apache-2.0"
+  head "https://github.com/risingwavelabs/risingwave.git", branch: "main"
+
+  bottle do
+    root_url "https://github.com/risingwavelabs/homebrew-risingwave/releases/download/risingwave-1.6.0"
+    sha256 cellar: :any, arm64_ventura: "2541d374428a4a988666f85f5a21b4b3122ea619d914179c7c111b5b35b373e3"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "llvm" => :build
+  depends_on "protobuf" => :build
+  depends_on "rustup-init" => :build
+  depends_on "openssl@3"
+  depends_on "xz"
+
+  def install
+    # this will install the necessary cargo/rustup toolchain bits in HOMEBREW_CACHE
+    system "#{Formula["rustup-init"].bin}/rustup-init",
+           "-qy", "--no-modify-path",
+           "--default-toolchain", "none"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+
+    ENV.delete "RUSTFLAGS" # https://github.com/Homebrew/brew/pull/15544#issuecomment-1628639703
+    # Homebrew changes cxx flags, and CMake doesn't pick them up, so rdkafka-sys build fails.
+    # We cannot pass CMake flags (`std_cmake_args`) because it's in their build.rs.
+    #
+    # Some refs that might be useful:
+    # https://github.com/Homebrew/homebrew-core/pull/51949#issuecomment-601943075
+    # https://github.com/Homebrew/brew/pull/7134
+    ENV["SDKROOT"] = MacOS.sdk_path_if_needed
+    system "cargo", "install",
+           "--bin", "risingwave",
+           "--features", "rw-static-link",
+           *std_cargo_args(path: "src/cmd_all") # "--locked", "--root ...", "--path src/cmd_all"
+  end
+
+  test do
+    system "#{bin}/risingwave", "--help"
+  end
+end

--- a/Formula/risingwave@1.7.0-single-node.rb
+++ b/Formula/risingwave@1.7.0-single-node.rb
@@ -1,0 +1,45 @@
+class Risingwave < Formula
+  desc "Distributed SQL database for stream processing"
+  homepage "https://github.com/risingwavelabs/risingwave"
+  url "https://github.com/risingwavelabs/risingwave/archive/refs/tags/v1.7.0-single-node.tar.gz"
+  sha256 "acf09b1f3b565ce5b57d420a408e5efdc38fee2b5c716b22aca3962f62267037"
+  license "Apache-2.0"
+  head "https://github.com/risingwavelabs/risingwave.git", branch: "main"
+
+  bottle do
+    root_url "https://github.com/risingwavelabs/homebrew-risingwave/releases/download/risingwave-1.6.0"
+    sha256 cellar: :any, arm64_ventura: "2541d374428a4a988666f85f5a21b4b3122ea619d914179c7c111b5b35b373e3"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "llvm" => :build
+  depends_on "protobuf" => :build
+  depends_on "rustup-init" => :build
+  depends_on "openssl@3"
+  depends_on "xz"
+
+  def install
+    # this will install the necessary cargo/rustup toolchain bits in HOMEBREW_CACHE
+    system "#{Formula["rustup-init"].bin}/rustup-init",
+           "-qy", "--no-modify-path",
+           "--default-toolchain", "none"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+
+    ENV.delete "RUSTFLAGS" # https://github.com/Homebrew/brew/pull/15544#issuecomment-1628639703
+    # Homebrew changes cxx flags, and CMake doesn't pick them up, so rdkafka-sys build fails.
+    # We cannot pass CMake flags (`std_cmake_args`) because it's in their build.rs.
+    #
+    # Some refs that might be useful:
+    # https://github.com/Homebrew/homebrew-core/pull/51949#issuecomment-601943075
+    # https://github.com/Homebrew/brew/pull/7134
+    ENV["SDKROOT"] = MacOS.sdk_path_if_needed
+    system "cargo", "install",
+           "--bin", "risingwave",
+           "--features", "rw-static-link",
+           *std_cargo_args(path: "src/cmd_all") # "--locked", "--root ...", "--path src/cmd_all"
+  end
+
+  test do
+    system "#{bin}/risingwave", "--help"
+  end
+end


### PR DESCRIPTION
1. Persist `1.6-rb`.
2. Add 1.7.0.

Don't bump `risingwave` cask.