### PR TITLE
Revert "Update Homebrew formula to pull through Scarf endpoint"

### DIFF
--- a/Formula/risingwave.rb
+++ b/Formula/risingwave.rb
@@ -1,7 +1,7 @@
 class Risingwave < Formula
   desc "Distributed SQL database for stream processing"
   homepage "https://github.com/risingwavelabs/risingwave"
-  url "https://risingwave.gateway.scarf.sh/risingwave/archive/refs/tags/v1.8.1.tar.gz"
+  url "https://github.com/risingwavelabs/risingwave/archive/refs/tags/v1.8.1.tar.gz"
   sha256 "bb4c2a7c6bcc3f8509e1ae25a06cf12bfec87f52bbc2a1e3e840bdea77e76353"
   license "Apache-2.0"
   head "https://github.com/risingwavelabs/risingwave.git", branch: "main"
@@ -19,7 +19,7 @@ class Risingwave < Formula
   depends_on "openssl@3"
 
   resource "connector" do
-    url "https://risingwave.gateway.scarf.sh/risingwave/releases/download/v1.8.0/risingwave-v1.8.0-x86_64-unknown-linux-all-in-one.tar.gz"
+    url "https://github.com/risingwavelabs/risingwave/releases/download/v1.8.0/risingwave-v1.8.0-x86_64-unknown-linux-all-in-one.tar.gz"
     sha256 "341fd43fe75535732e67f11dee544cf309b30a30ad76370a6d5313dc6a5147e5"
   end
 


### PR DESCRIPTION
Reverts risingwavelabs/homebrew-risingwave#39

The links changed in that PR only count when building a bottle from the formula, which typically occurs only once for each release on CI. Most of the users will directly download the bottle so the changes are useless.

On the other side, we can directly obtain the data from GitHub to count the download times of the bottle.

<img width="716" alt="image" src="https://github.com/risingwavelabs/homebrew-risingwave/assets/25862682/35e4e6aa-5b61-4c9b-9cd4-3d4a761f78f7">
