### PR TITLE
increase memory limit for building dashboard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # For macOS, large is Intel and XLarge is M1
+        # For macOS, large is Intel and xlarge is Apple Silicon
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners
-        os: [macos-13-large, macos-13-xlarge]
+        os: [
+            # macos-13-large, # deprecated bottle for Intel Macs
+            macos-13-xlarge,
+          ]
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_NO_INSTALL_FROM_API: 1 # https://github.com/Homebrew/brew/issues/15049

--- a/Formula/risingwave.rb
+++ b/Formula/risingwave.rb
@@ -4,6 +4,7 @@ class Risingwave < Formula
   url "https://github.com/risingwavelabs/risingwave/archive/refs/tags/v2.5.1.tar.gz"
   sha256 "e50ecbdbc70a3c1d17c5369f0d64c9091efb9c42430ce688ab4bfce69f54962c"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/risingwavelabs/risingwave.git", branch: "main"
 
   bottle do
@@ -59,6 +60,9 @@ class Risingwave < Formula
 
     # Enable building embedded dashboard.
     ENV["ENABLE_BUILD_DASHBOARD"] = "1" if build.without?("dev-profile")
+
+    # Increase memory limit for Node.js for building dashboard.
+    ENV["NODE_OPTIONS"] = "--max-old-space-size=8192"
 
     # Currently we don't support Python 3.13.
     ENV["PYO3_PYTHON"] = "python3.12"


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

Also deprecate building bottle for Intel Macs.